### PR TITLE
Forbedrer byggetid

### DIFF
--- a/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/HistorikkinnslagTest.kt
+++ b/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/HistorikkinnslagTest.kt
@@ -68,12 +68,8 @@ class HistorikkinnslagTest(
             )
             erBehandlingPåVent(Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING)
 
-            Thread.sleep(10_000)
-
             taBehandlingAvVent()
             erBehandlingPåVent(Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG)
-
-            Thread.sleep(10_000)
 
             opprettKravgrunnlag(
                 status = KodeStatusKrav.NY,
@@ -83,17 +79,11 @@ class HistorikkinnslagTest(
             )
             erBehandlingISteg(Behandlingssteg.FAKTA, Behandlingsstegstatus.KLAR)
 
-            Thread.sleep(10_000)
-
             behandleFakta(Hendelsestype.ANNET, Hendelsesundertype.ANNET_FRITEKST)
             erBehandlingISteg(Behandlingssteg.FORELDELSE, Behandlingsstegstatus.KLAR)
 
-            Thread.sleep(10_000)
-
             behandleForeldelse(beslutning = Foreldelsesvurderingstype.IKKE_FORELDET)
             erBehandlingISteg(Behandlingssteg.VILKÅRSVURDERING, Behandlingsstegstatus.KLAR)
-
-            Thread.sleep(10_000)
 
             behandleVilkårsvurdering(
                 vilkårvurderingsresultat = Vilkårsvurderingsresultat.FORSTO_BURDE_FORSTÅTT,
@@ -108,24 +98,16 @@ class HistorikkinnslagTest(
             )
             erBehandlingISteg(Behandlingssteg.FORESLÅ_VEDTAK, Behandlingsstegstatus.KLAR)
 
-            Thread.sleep(10_000)
-
             bestillBrev(Dokumentmalstype.INNHENT_DOKUMENTASJON)
             taBehandlingAvVent()
-
-            Thread.sleep(10_000)
 
             beregn()
             behandleForeslåVedtak()
             erBehandlingISteg(Behandlingssteg.FATTE_VEDTAK, Behandlingsstegstatus.KLAR)
 
-            Thread.sleep(10_000)
-
             endreAnsvarligSaksbehandler(Saksbehandler.BESLUTTER_IDENT)
             behandleFatteVedtak(godkjent = true)
             erBehandlingAvsluttet(resultat = Behandlingsresultatstype.FULL_TILBAKEBETALING)
-
-            Thread.sleep(30_000)
 
             saksbehandler.verifiserHistorikkinnslag()
         }

--- a/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingBATest.kt
+++ b/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingBATest.kt
@@ -324,6 +324,8 @@ class OpprettTilbakekrevingBATest(@Autowired val familieTilbakeKlient: FamilieTi
                 muligforeldelse = false
             )
 
+            Thread.sleep(5000)
+
             kanBehandlingOpprettesManuelt(scenario)
             oppretManuellBehandling(scenario = scenario, detaljertMelding = detaljertMelding)
 

--- a/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingBATest.kt
+++ b/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingBATest.kt
@@ -64,8 +64,6 @@ class OpprettTilbakekrevingBATest(@Autowired val familieTilbakeKlient: FamilieTi
             )
             erBehandlingPåVent(Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING)
 
-            Thread.sleep(10_000)
-
             taBehandlingAvVent()
             erBehandlingPåVent(Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG)
 
@@ -251,8 +249,6 @@ class OpprettTilbakekrevingBATest(@Autowired val familieTilbakeKlient: FamilieTi
             )
             erBehandlingPåVent(Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING)
 
-            Thread.sleep(10_000)
-
             taBehandlingAvVent()
             erBehandlingPåVent(Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG)
 
@@ -327,8 +323,6 @@ class OpprettTilbakekrevingBATest(@Autowired val familieTilbakeKlient: FamilieTi
                 under4rettsgebyr = false,
                 muligforeldelse = false
             )
-
-            Thread.sleep(5_000)
 
             kanBehandlingOpprettesManuelt(scenario)
             oppretManuellBehandling(scenario = scenario, detaljertMelding = detaljertMelding)
@@ -514,8 +508,6 @@ class OpprettTilbakekrevingBATest(@Autowired val familieTilbakeKlient: FamilieTi
             )
             erBehandlingPåVent(Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING)
 
-            Thread.sleep(10_000)
-
             taBehandlingAvVent()
             erBehandlingPåVent(Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG)
 
@@ -632,8 +624,6 @@ class OpprettTilbakekrevingBATest(@Autowired val familieTilbakeKlient: FamilieTi
                 verge = false
             )
             erBehandlingPåVent(Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING)
-
-            Thread.sleep(10_000)
 
             taBehandlingAvVent()
             erBehandlingPåVent(Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG)

--- a/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingBTTest.kt
+++ b/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingBTTest.kt
@@ -59,8 +59,6 @@ class OpprettTilbakekrevingBTTest(@Autowired val familieTilbakeKlient: FamilieTi
             )
             erBehandlingPåVent(Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING)
 
-            Thread.sleep(10_000)
-
             taBehandlingAvVent()
             erBehandlingPåVent(Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG)
 
@@ -156,8 +154,6 @@ class OpprettTilbakekrevingBTTest(@Autowired val familieTilbakeKlient: FamilieTi
                 verge = false
             )
             erBehandlingPåVent(Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING)
-
-            Thread.sleep(10_000)
 
             taBehandlingAvVent()
             erBehandlingPåVent(Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG)

--- a/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingOSTest.kt
+++ b/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingOSTest.kt
@@ -59,8 +59,6 @@ class OpprettTilbakekrevingOSTest(@Autowired val familieTilbakeKlient: FamilieTi
             )
             erBehandlingPåVent(Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING)
 
-            Thread.sleep(10_000)
-
             taBehandlingAvVent()
             erBehandlingPåVent(Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG)
 
@@ -157,8 +155,6 @@ class OpprettTilbakekrevingOSTest(@Autowired val familieTilbakeKlient: FamilieTi
             )
             erBehandlingPåVent(Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING)
 
-            Thread.sleep(10_000)
-
             taBehandlingAvVent()
             erBehandlingPåVent(Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG)
 
@@ -201,8 +197,6 @@ class OpprettTilbakekrevingOSTest(@Autowired val familieTilbakeKlient: FamilieTi
                 verge = false
             )
             erBehandlingPåVent(Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING)
-
-            Thread.sleep(10_000)
 
             taBehandlingAvVent()
             erBehandlingPåVent(Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG)

--- a/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingSPTest.kt
+++ b/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingSPTest.kt
@@ -59,8 +59,6 @@ class OpprettTilbakekrevingSPTest(@Autowired val familieTilbakeKlient: FamilieTi
             )
             erBehandlingPåVent(Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING)
 
-            Thread.sleep(10_000)
-
             taBehandlingAvVent()
             erBehandlingPåVent(Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG)
 
@@ -156,8 +154,6 @@ class OpprettTilbakekrevingSPTest(@Autowired val familieTilbakeKlient: FamilieTi
                 verge = false
             )
             erBehandlingPåVent(Venteårsak.VENT_PÅ_BRUKERTILBAKEMELDING)
-
-            Thread.sleep(10_000)
 
             taBehandlingAvVent()
             erBehandlingPåVent(Venteårsak.VENT_PÅ_TILBAKEKREVINGSGRUNNLAG)


### PR DESCRIPTION
Fjerner `thread.sleep`, da det ser ut til at det er laget en `Vent.til()` funksjon som gjør at det ikke trengs lenger.