### PR TITLE
Forenkle oppsett av testdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ eksternFagsakid og eksternBrukId finner du i loggen for testkjøringa.
 
 ## Opprett testdata for lokal utvikling
 - Kjør opp `familie-tilbake`, `familie-tilbake-frontend` og `familie-historikk`
-- Sett nødvendig miljøvariabel (Krever at du er pålogget naisdevice og gcloud) `export TILBAKE_CLIENT_SECRET=$(kubectl -n teamfamilie get secret azuread-familie-tilbake-frontend-lokal -o json | jq '.data | map_values(@base64d)' | jq -r '.AZURE_APP_CLIENT_SECRET')`
-- Kjør tester `mvn -e -Dspring.profiles.active=local test`. 
+- Gå inn i autotestmappa `cd autotest`
+- De neste stegene krever at du er pålogget naisdevice og gcloud
+- Kjør tester `source hent_tilbake_client_secret.sh && mvn -e -Dspring.profiles.active=local test`. 
   - Evt så kan du slenge på hvilken test du vil kjøre:
-  - Eksempel BA: `mvn -e -Dspring.profiles.active=local test -Dtest='OpprettTilbakekrevingBATest#Oppretter uavsluttet delvis tilbakekreving for bruk ved utvikling'`
-  - Eksempel EF: `mvn -e -Dspring.profiles.active=local test -Dtest='OpprettTilbakekrevingOsTest.Opprett dummy-test-data lokalt'`
+  - Eksempel BA: `source hent_tilbake_client_secret.sh && mvn -e -Dspring.profiles.active=local test -Dtest='OpprettTilbakekrevingBATest#Oppretter uavsluttet delvis tilbakekreving for bruk ved utvikling'`
+  - Eksempel EF: `source hent_tilbake_client_secret.sh && mvn -e -Dspring.profiles.active=local test -Dtest='OpprettTilbakekrevingOsTest.Opprett dummy-test-data lokalt'`
 
 
 Eksempel: 

--- a/autotest/hent_tilbake_client_secret.sh
+++ b/autotest/hent_tilbake_client_secret.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+TILBAKE_CLIENT_SECRET=$(kubectl -n teamfamilie get secret azuread-familie-tilbake-frontend-lokal -o json | jq '.data | map_values(@base64d)' | jq -r '.AZURE_APP_CLIENT_SECRET')
+export TILBAKE_CLIENT_SECRET


### PR DESCRIPTION
Nå exporter vi miljøvariablene og kjører koden i to forskjellige steg. Det gjør at vi får en feil dersom vi prøver å kjøre testene i en ny terminal.

Endrer så vi setter miljøvariabel i samme commando som setter opp dataene.