### PR TITLE
Fix: Compose V1 -> Compose V2

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   familie-mock-server:
     image: europe-north1-docker.pkg.dev/nais-management-233d/teamfamilie/familie-mock-server:latest

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -18,7 +18,7 @@ docker compose build
 dockercompose=`cat docker-compose.yml`
 detviskalfinne="docker.pkg.github.com/navikt/$appsombyggeslokalt/$appsombyggeslokalt:latest"
 
-echo "${dockercompose/$detviskalfinne/$appversjonlokalt}" | docker-compose -f - up -d --force-recreate
+echo "${dockercompose/$detviskalfinne/$appversjonlokalt}" | docker compose -f - up -d --force-recreate
 
 while [[ $(curl -s -X GET "http://localhost:8030/internal/health") == "" ]]; do
     echo "venter på oppstart av tilbake / integrasjoner"

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -12,8 +12,8 @@ else
   echo "starter e2e med $appsombyggeslokalt på versjon $appversjonlokalt "
 fi
 
-docker-compose pull --quiet
-docker-compose build
+docker compose pull --quiet
+docker compose build
 
 dockercompose=`cat docker-compose.yml`
 detviskalfinne="docker.pkg.github.com/navikt/$appsombyggeslokalt/$appsombyggeslokalt:latest"


### PR DESCRIPTION
GitHub Actions støtter ikke lenger Compose V1 og vi er nødt til å gå over til Compose V2. For oss betyr dette at vi må erstatte `docker-compose` med `docker compose` (altså fjerne bindestrek) i `e2e.sh`. Fjerner også `version` fra `docker-compose.yaml` for å fjerne warningen "docker-compose.yml: 'version' is obsolete"