### PR TITLE
Bugfix i familie-tilbake gjør at eksternId blir brukt i kall, og det kreves derfor at alle kall med eksternId er UUID

### DIFF
--- a/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingBATest.kt
+++ b/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingBATest.kt
@@ -29,6 +29,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.annotation.IfProfileValue
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.util.UUID
 import kotlin.random.Random
 
 @SpringBootTest(classes = [ApplicationConfig::class])
@@ -44,15 +45,17 @@ class OpprettTilbakekrevingBATest(@Autowired val familieTilbakeKlient: FamilieTi
     @BeforeEach
     fun setup() {
         saksbehandler = Saksbehandler(familieTilbakeKlient = familieTilbakeKlient)
+        val eksternBehandlingId = UUID.randomUUID().toString()
         scenario = Scenario(
             eksternFagsakId = Random.nextInt(1000000, 9999999).toString(),
-            eksternBehandlingId = Random.nextInt(1000000, 9999999).toString(),
+            eksternBehandlingId = eksternBehandlingId,
             fagsystem = fagsystem,
             ytelsestype = ytelsestype,
             personIdent = "12345678901",
             enhetId = "0106",
             enhetsnavn = "NAV Fredrikstad"
         )
+        println("Ekstern behandlingId: $eksternBehandlingId")
     }
 
     @Test
@@ -324,6 +327,7 @@ class OpprettTilbakekrevingBATest(@Autowired val familieTilbakeKlient: FamilieTi
                 under4rettsgebyr = false,
                 muligforeldelse = false
             )
+            println("asdf: ${scenario.eksternBehandlingId}")
 
             Thread.sleep(5000)
 

--- a/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingBTTest.kt
+++ b/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingBTTest.kt
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.util.UUID
 import kotlin.random.Random
 
 @SpringBootTest(classes = [ApplicationConfig::class])
@@ -40,7 +41,7 @@ class OpprettTilbakekrevingBTTest(@Autowired val familieTilbakeKlient: FamilieTi
         saksbehandler = Saksbehandler(familieTilbakeKlient = familieTilbakeKlient)
         scenario = Scenario(
             eksternFagsakId = Random.nextInt(1000000, 9999999).toString(),
-            eksternBehandlingId = Random.nextInt(1000000, 9999999).toString(),
+            eksternBehandlingId = UUID.randomUUID().toString(),
             fagsystem = fagsystem,
             ytelsestype = ytelsestype,
             personIdent = "12345678901",

--- a/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingOSTest.kt
+++ b/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingOSTest.kt
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.util.UUID
 import kotlin.random.Random
 
 @SpringBootTest(classes = [ApplicationConfig::class])
@@ -40,7 +41,7 @@ class OpprettTilbakekrevingOSTest(@Autowired val familieTilbakeKlient: FamilieTi
         saksbehandler = Saksbehandler(familieTilbakeKlient = familieTilbakeKlient)
         scenario = Scenario(
             eksternFagsakId = Random.nextInt(1000000, 9999999).toString(),
-            eksternBehandlingId = Random.nextInt(1000000, 9999999).toString(),
+            eksternBehandlingId = UUID.randomUUID().toString(),
             fagsystem = fagsystem,
             ytelsestype = ytelsestype,
             personIdent = "12345678901",

--- a/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingSPTest.kt
+++ b/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/autotest/OpprettTilbakekrevingSPTest.kt
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.util.UUID
 import kotlin.random.Random
 
 @SpringBootTest(classes = [ApplicationConfig::class])
@@ -40,7 +41,7 @@ class OpprettTilbakekrevingSPTest(@Autowired val familieTilbakeKlient: FamilieTi
         saksbehandler = Saksbehandler(familieTilbakeKlient = familieTilbakeKlient)
         scenario = Scenario(
             eksternFagsakId = Random.nextInt(1000000, 9999999).toString(),
-            eksternBehandlingId = Random.nextInt(1000000, 9999999).toString(),
+            eksternBehandlingId = UUID.randomUUID().toString(),
             fagsystem = fagsystem,
             ytelsestype = ytelsestype,
             personIdent = "12345678901",

--- a/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/felles/Saksbehandler.kt
+++ b/autotest/src/test/kotlin/no/nav/familie/tilbake/e2e/felles/Saksbehandler.kt
@@ -48,7 +48,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class Saksbehandler(
-    private val familieTilbakeKlient: FamilieTilbakeKlient,
+    private val familieTilbakeKlient: FamilieTilbakeKlient
 ) {
 
     companion object {


### PR DESCRIPTION
Denne endringen gjør at e2e-testene vil kjøre med i PR: https://github.com/navikt/familie-tilbake/pull/1536